### PR TITLE
Add more wait for execution of deletion of the rois

### DIFF
--- a/maintenance/cleanup.py
+++ b/maintenance/cleanup.py
@@ -132,8 +132,9 @@ def delete_objs(conn):
         print 'No tag links to delete'
     if len(obj_ids_rois) > 0:
         print 'deleting %s ROIs' % len(obj_ids_rois)
-        conn.deleteObjects("Roi", obj_ids_rois, deleteAnns=True,
-                           deleteChildren=True, wait=True)
+        handle = conn.deleteObjects("Roi", obj_ids_rois, deleteAnns=True,
+                             deleteChildren=True)
+        conn.c.waitOnCmd(handle, loops=500, ms=500, closehandle=True)
     else:
         print 'No ROIs to delete'
     if len(obj_ids_rating) > 0:


### PR DESCRIPTION
A suggestion to enable the ``cleanup.py`` to deal with large numbers of objects to be deleted.

See rationale on https://github.com/ome/training-scripts/pull/4#issuecomment-380466799

cc @jburel 

Thank you @mtbc 