### PR TITLE
One more space for windowless

### DIFF
--- a/practical/groovy/analyse_dataset_save_rois_and_summary_table.groovy
+++ b/practical/groovy/analyse_dataset_save_rois_and_summary_table.groovy
@@ -135,7 +135,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, PORT, group_id, image_id) {
     options.append("\niid=")
     options.append(image_id)
     options.append("] ")
-    options.append("windowless=true")
+    options.append("windowless=true ")
     IJ.runPlugIn("loci.plugins.LociImporter", options.toString())
 }
 


### PR DESCRIPTION
Addition of one crucial space to ``windowless=true`` which makes the option finally execute in Fiji and thus the BF importer does not throw the options window anymore. 

See testing and explanation in 

cc @jburel